### PR TITLE
fix(lspsaga): guard catppuccin kind icons behind active colorscheme

### DIFF
--- a/lua/modules/configs/completion/lspsaga.lua
+++ b/lua/modules/configs/completion/lspsaga.lua
@@ -3,7 +3,7 @@ return function()
 
 	-- Only align kind icons to catppuccin's set when catppuccin is the active
 	-- colorscheme; other themes fall back to Lspsaga's built-in icons untouched.
-	local has_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
+	local has_catppuccin = (vim.g.colors_name or ""):find("catppuccin") ~= nil
 
 	local icons = {
 		cmp = require("modules.utils.icons").get("cmp", true),

--- a/lua/modules/configs/completion/lspsaga.lua
+++ b/lua/modules/configs/completion/lspsaga.lua
@@ -1,6 +1,10 @@
 return function()
 	require("modules.utils").gen_lspkind_hl()
 
+	-- Only align kind icons to catppuccin's set when catppuccin is the active
+	-- colorscheme; other themes fall back to Lspsaga's built-in icons untouched.
+	local has_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
+
 	local icons = {
 		cmp = require("modules.utils.icons").get("cmp", true),
 		diagnostics = require("modules.utils.icons").get("diagnostics", true),
@@ -150,7 +154,7 @@ return function()
 			actionfix = icons.ui.Spell,
 			lines = { "┗", "┣", "┃", "━", "┏" },
 			imp_sign = icons.kind.Implementation,
-			kind = require("catppuccin.groups.integrations.lsp_saga").custom_kind(),
+			kind = has_catppuccin and require("catppuccin.groups.integrations.lsp_saga").custom_kind() or nil,
 		},
 		-- Scrolling Keymaps: https://nvimdev.github.io/lspsaga/misc/#scrolling-keymaps
 		scroll_preview = {


### PR DESCRIPTION
## What

Lspsaga's `ui.kind` previously called `require("catppuccin.groups.integrations.lsp_saga").custom_kind()` **unconditionally**. This forced catppuccin's icon set (and a hard `require` on the catppuccin integration) onto every user, regardless of the active colorscheme.

This PR guards that call behind the active colorscheme — the same `vim.g.colors_name:find("catppuccin")` pattern already used in `bufferline.lua` and `lualine.lua`.

```lua
local has_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
-- ...
kind = has_catppuccin and require("catppuccin.groups.integrations.lsp_saga").custom_kind() or nil,
```

## Behavior

- **catppuccin active** → unchanged: catppuccin's `custom_kind()` (icons + `LspKind*` highlights).
- **other themes** → `ui.kind` is `nil`, so Lspsaga uses its own built-in icon set + standard highlight groups, untouched. No forced catppuccin dependency.

## Why

Implements the opt-in approach proposed in ayamir/nvimdots#1415 ([comment](https://github.com/ayamir/nvimdots/issues/1415#issuecomment-4830533900)), addressing the concern that aligning to catppuccin's icons would otherwise affect users on other themes (gruvbox / tokyonight / etc.).

## Verification

- `stylua lua/` — clean (StyLua re-parses the full AST).
- Mirrors the existing colorscheme-guard convention already in the codebase.