### PR TITLE
fix(ui): guard against nil colors_name in lualine/bufferline

### DIFF
--- a/lua/modules/configs/ui/bufferline.lua
+++ b/lua/modules/configs/ui/bufferline.lua
@@ -40,7 +40,7 @@ return function()
 		highlights = {},
 	}
 
-	if vim.g.colors_name:find("catppuccin") then
+	if (vim.g.colors_name or ""):find("catppuccin") then
 		local cp = require("modules.utils").get_palette() -- Get the palette.
 
 		local catppuccin_hl_overwrite = {

--- a/lua/modules/configs/ui/lualine.lua
+++ b/lua/modules/configs/ui/lualine.lua
@@ -41,7 +41,7 @@ vim.api.nvim_create_autocmd("LspProgress", {
 })
 
 return function()
-	local has_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
+	local has_catppuccin = (vim.g.colors_name or ""):find("catppuccin") ~= nil
 	local colors = require("modules.utils").get_palette()
 	local icons = {
 		diagnostics = require("modules.utils.icons").get("diagnostics", true),
@@ -57,7 +57,7 @@ return function()
 			group = vim.api.nvim_create_augroup("LualineColorScheme", { clear = true }),
 			pattern = "*",
 			callback = function()
-				has_catppuccin = vim.g.colors_name:find("catppuccin") ~= nil
+				has_catppuccin = (vim.g.colors_name or ""):find("catppuccin") ~= nil
 				require("lualine").setup({ options = { theme = custom_theme() } })
 			end,
 		})


### PR DESCRIPTION
## What

`lualine.lua` and `bufferline.lua` call `vim.g.colors_name:find("catppuccin")` directly. `vim.g.colors_name` is `nil` until a colorscheme is applied (verified via `nvim --clean`), so `nil:find()` would error if these modules load before any `:colorscheme`.

Coalesce to an empty string in all three spots:

- `lua/modules/configs/ui/lualine.lua:44`
- `lua/modules/configs/ui/lualine.lua:60` (inside the `ColorScheme` autocmd callback)
- `lua/modules/configs/ui/bufferline.lua:43`

```lua
(vim.g.colors_name or ""):find("catppuccin")
```

## Why

This matches the safe pattern already used in `lua/modules/utils/init.lua:59,114`. It's the same defensive fix [Copilot flagged on #18](https://github.com/charliie-dev/nvimdots.lua/pull/18) for the Lspsaga config — that PR scoped the change to `lspsaga.lua`; this one aligns the two remaining UI configs that share the pattern.

Behaviour is unchanged when a colorscheme is set (`("catppuccin-mocha" or ""):find("catppuccin")` → match; `(nil or ""):find(...)` → no match, no error).

## Verification

- `stylua lua/` — clean.
- `grep 'vim.g.colors_name:find' lua/` → no unguarded occurrences remain.