### PR TITLE
fix(nixos): drop docformatter and unused packages breaking flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782760764,
-        "narHash": "sha256-N66fYdUuZ9hpdM7jsQ7CUWtLJduqGDyTGCaLR62CXaQ=",
+        "lastModified": 1784115452,
+        "narHash": "sha256-BoYPdqk6jlKXy+DyUzyGV/CtRGfAhk2MmIgBhsemTGI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7a1a64774a5fd0b0cd39ac95d0e170ace8b266a0",
+        "rev": "35d3407a3816f3b341d8cf1d60abaf2b7b8166ac",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,9 +13,10 @@
   };
 
   outputs =
-    inputs@{ self
-    , flake-parts
-    , ...
+    inputs@{
+      self,
+      flake-parts,
+      ...
     }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
@@ -29,9 +30,10 @@
         "aarch64-darwin"
       ];
       perSystem =
-        { pkgs
-        , system
-        , ...
+        {
+          pkgs,
+          system,
+          ...
         }:
         {
           packages = {

--- a/flake.nix
+++ b/flake.nix
@@ -106,7 +106,7 @@
             ];
             packages = with pkgs; [
               nixd
-              nixpkgs-fmt
+              nixfmt-rfc-style
             ];
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,5 @@
 {
   # This provides only NixOS module
-  # As of 2023/08/19, you need to depend on nixpkgs-unstable.
-  # because "doq" is not included in the stable version.
   description = "Provide nixosModules for CharlesChiuGit/nvimdots.lua";
 
   inputs = {

--- a/nixos/neovim/default.nix
+++ b/nixos/neovim/default.nix
@@ -1,8 +1,9 @@
 # home-manager module of neovim setup
-{ config
-, lib
-, pkgs
-, ...
+{
+  config,
+  lib,
+  pkgs,
+  ...
 }:
 let
   cfg = config.programs.neovim.nvimdots;
@@ -59,15 +60,13 @@ in
             let
               fromType = listOf package;
             in
-            coercedTo fromType
-              (flip warn const ''
-                Assigning a plain list to extraHaskellPackages is deprecated.
-                       Please assign a function taking a package set as argument, so
-                         extraHaskellPackages = [ pkgs.haskellPackages.xxx ];
-                       should become
-                         extraHaskellPackages = ps: [ ps.xxx ];
-              '')
-              (functionTo fromType);
+            coercedTo fromType (flip warn const ''
+              Assigning a plain list to extraHaskellPackages is deprecated.
+                     Please assign a function taking a package set as argument, so
+                       extraHaskellPackages = [ pkgs.haskellPackages.xxx ];
+                     should become
+                       extraHaskellPackages = ps: [ ps.xxx ];
+            '') (functionTo fromType);
           default = _: [ ];
           defaultText = literalExpression "ps: [ ]";
           example = literalExpression "hsPkgs: with hsPkgs; [ mtl ]";
@@ -127,12 +126,12 @@ in
       };
 
       buildEnv = [
-        ''CPATH=''${CPATH:+''${CPATH}:}${neovim-build-deps}/include''
-        ''CPLUS_INCLUDE_PATH=''${CPLUS_INCLUDE_PATH:+''${CPLUS_INCLUDE_PATH}:}${neovim-build-deps}/include/c++/v1''
-        ''LD_LIBRARY_PATH=''${LD_LIBRARY_PATH:+''${LD_LIBRARY_PATH}:}${neovim-build-deps}/lib''
-        ''LIBRARY_PATH=''${LIBRARY_PATH:+''${LIBRARY_PATH}:}${neovim-build-deps}/lib''
-        ''NIX_LD_LIBRARY_PATH=''${NIX_LD_LIBRARY_PATH:+''${NIX_LD_LIBRARY_PATH}:}${neovim-build-deps}/lib''
-        ''PKG_CONFIG_PATH=''${PKG_CONFIG_PATH:+''${PKG_CONFIG_PATH}:}${neovim-build-deps}/include/pkgconfig''
+        "CPATH=\${CPATH:+\${CPATH}:}${neovim-build-deps}/include"
+        "CPLUS_INCLUDE_PATH=\${CPLUS_INCLUDE_PATH:+\${CPLUS_INCLUDE_PATH}:}${neovim-build-deps}/include/c++/v1"
+        "LD_LIBRARY_PATH=\${LD_LIBRARY_PATH:+\${LD_LIBRARY_PATH}:}${neovim-build-deps}/lib"
+        "LIBRARY_PATH=\${LIBRARY_PATH:+\${LIBRARY_PATH}:}${neovim-build-deps}/lib"
+        "NIX_LD_LIBRARY_PATH=\${NIX_LD_LIBRARY_PATH:+\${NIX_LD_LIBRARY_PATH}:}${neovim-build-deps}/lib"
+        "PKG_CONFIG_PATH=\${PKG_CONFIG_PATH:+\${PKG_CONFIG_PATH}:}${neovim-build-deps}/include/pkgconfig"
       ];
     in
     mkIf cfg.enable {
@@ -142,32 +141,31 @@ in
           message = "bindLazyLock and mergeLazyLock cannot be enabled at the same time.";
         }
       ];
-      xdg.configFile =
-        {
-          "nvim/init.lua".source = ../../init.lua;
-          "nvim/lua".source = ../../lua;
-          "nvim/snips".source = ../../snips;
-        }
-        // optionalAttrs cfg.bindLazyLock {
-          "nvim/lazy-lock.json".source = ../../lazy-lock.json;
-        }
-        // optionalAttrs cfg.mergeLazyLock {
-          "nvim/lazy-lock.nix.json" = {
-            source = ../../lazy-lock.json;
-            onChange = ''
-              if [ -f ${config.xdg.configHome}/nvim/lazy-lock.json ]; then
-                tmp=$(mktemp)
-                ${pkgs.jq}/bin/jq -r -s '.[0] * .[1]' ${config.xdg.configHome}/nvim/lazy-lock.json ${
-                  config.xdg.configFile."nvim/lazy-lock.nix.json".source
-                } > "''${tmp}" && mv "''${tmp}" ${config.xdg.configHome}/nvim/lazy-lock.json
-              else
-                ${pkgs.rsync}/bin/rsync --chmod 644 ${
-                  config.xdg.configFile."nvim/lazy-lock.nix.json".source
-                } ${config.xdg.configHome}/nvim/lazy-lock.json
-              fi
-            '';
-          };
+      xdg.configFile = {
+        "nvim/init.lua".source = ../../init.lua;
+        "nvim/lua".source = ../../lua;
+        "nvim/snips".source = ../../snips;
+      }
+      // optionalAttrs cfg.bindLazyLock {
+        "nvim/lazy-lock.json".source = ../../lazy-lock.json;
+      }
+      // optionalAttrs cfg.mergeLazyLock {
+        "nvim/lazy-lock.nix.json" = {
+          source = ../../lazy-lock.json;
+          onChange = ''
+            if [ -f ${config.xdg.configHome}/nvim/lazy-lock.json ]; then
+              tmp=$(mktemp)
+              ${pkgs.jq}/bin/jq -r -s '.[0] * .[1]' ${config.xdg.configHome}/nvim/lazy-lock.json ${
+                config.xdg.configFile."nvim/lazy-lock.nix.json".source
+              } > "''${tmp}" && mv "''${tmp}" ${config.xdg.configHome}/nvim/lazy-lock.json
+            else
+              ${pkgs.rsync}/bin/rsync --chmod 644 ${
+                config.xdg.configFile."nvim/lazy-lock.nix.json".source
+              } ${config.xdg.configHome}/nvim/lazy-lock.json
+            fi
+          '';
         };
+      };
       home = {
         packages = [
           pkgs.ripgrep
@@ -176,72 +174,70 @@ in
           nvim = concatStringsSep " " buildEnv + " nvim";
         };
       };
-      programs.neovim =
-        {
-          enable = true;
+      programs.neovim = {
+        enable = true;
 
-          withNodeJs = true;
-          withPython3 = true;
+        withNodeJs = true;
+        withPython3 = true;
 
-          extraPackages =
-            [
-              # Dependent packages used by default plugins
-              pkgs.tree-sitter
-            ]
-            ++ optionals cfg.withBuildTools [
-              pkgs.cargo
-              pkgs.clang
-              pkgs.cmake
-              pkgs.gcc
-              pkgs.gnumake
-              pkgs.go
-              pkgs.lua51Packages.luarocks
-              pkgs.ninja
-              pkgs.pkg-config
-              pkgs.yarn
-            ]
-            ++ optionals cfg.withHaskell [
-              (pkgs.writeShellApplication {
-                name = "stack";
-                text = ''
-                  exec "${pkgs.stack}/bin/stack" "--extra-include-dirs=${config.home.profileDirectory}/lib/nvim-depends/include" "--extra-lib-dirs=${config.home.profileDirectory}/lib/nvim-depends/lib" "$@"
-                '';
-              })
-              (pkgs.haskellPackages.ghcWithPackages (ps: cfg.extraHaskellPackages ps))
-            ];
+        extraPackages = [
+          # Dependent packages used by default plugins
+          pkgs.tree-sitter
+        ]
+        ++ optionals cfg.withBuildTools [
+          pkgs.cargo
+          pkgs.clang
+          pkgs.cmake
+          pkgs.gcc
+          pkgs.gnumake
+          pkgs.go
+          pkgs.lua51Packages.luarocks
+          pkgs.ninja
+          pkgs.pkg-config
+          pkgs.yarn
+        ]
+        ++ optionals cfg.withHaskell [
+          (pkgs.writeShellApplication {
+            name = "stack";
+            text = ''
+              exec "${pkgs.stack}/bin/stack" "--extra-include-dirs=${config.home.profileDirectory}/lib/nvim-depends/include" "--extra-lib-dirs=${config.home.profileDirectory}/lib/nvim-depends/lib" "$@"
+            '';
+          })
+          (pkgs.haskellPackages.ghcWithPackages (ps: cfg.extraHaskellPackages ps))
+        ];
 
-          extraPython3Packages =
-            ps: with ps; [
-              pynvim
-            ];
-        }
-        // optionalAttrs (versionAtLeast config.home.stateVersion "24.05") {
-          extraWrapperArgs = optionals cfg.setBuildEnv [
-            "--suffix"
-            "CPATH"
-            ":"
-            "${neovim-build-deps}/include"
-            "--suffix"
-            "CPLUS_INCLUDE_PATH"
-            ":"
-            "${neovim-build-deps}/include/c++/v1"
-            "--suffix"
-            "LD_LIBRARY_PATH"
-            ":"
-            "${neovim-build-deps}/lib"
-            "--suffix"
-            "LIBRARY_PATH"
-            ":"
-            "${neovim-build-deps}/lib"
-            "--suffix"
-            "PKG_CONFIG_PATH"
-            ":"
-            "${neovim-build-deps}/include/pkgconfig"
-            "--suffix"
-            "NIX_LD_LIBRARY_PATH"
-            ":"
-            "${neovim-build-deps}/lib"
+        extraPython3Packages =
+          ps: with ps; [
+            pynvim
           ];
-        };
+      }
+      // optionalAttrs (versionAtLeast config.home.stateVersion "24.05") {
+        extraWrapperArgs = optionals cfg.setBuildEnv [
+          "--suffix"
+          "CPATH"
+          ":"
+          "${neovim-build-deps}/include"
+          "--suffix"
+          "CPLUS_INCLUDE_PATH"
+          ":"
+          "${neovim-build-deps}/include/c++/v1"
+          "--suffix"
+          "LD_LIBRARY_PATH"
+          ":"
+          "${neovim-build-deps}/lib"
+          "--suffix"
+          "LIBRARY_PATH"
+          ":"
+          "${neovim-build-deps}/lib"
+          "--suffix"
+          "PKG_CONFIG_PATH"
+          ":"
+          "${neovim-build-deps}/include/pkgconfig"
+          "--suffix"
+          "NIX_LD_LIBRARY_PATH"
+          ":"
+          "${neovim-build-deps}/lib"
+        ];
+      };
     };
 }

--- a/nixos/neovim/default.nix
+++ b/nixos/neovim/default.nix
@@ -128,7 +128,7 @@ in
 
       buildEnv = [
         ''CPATH=''${CPATH:+''${CPATH}:}${neovim-build-deps}/include''
-        ''CPLUS_INCLUDE_PATH=''${CPLUS_INCLUDE_PATH:+''${CPLUS_INCLUDE_PATH}:}:${neovim-build-deps}/include/c++/v1''
+        ''CPLUS_INCLUDE_PATH=''${CPLUS_INCLUDE_PATH:+''${CPLUS_INCLUDE_PATH}:}${neovim-build-deps}/include/c++/v1''
         ''LD_LIBRARY_PATH=''${LD_LIBRARY_PATH:+''${LD_LIBRARY_PATH}:}${neovim-build-deps}/lib''
         ''LIBRARY_PATH=''${LIBRARY_PATH:+''${LIBRARY_PATH}:}${neovim-build-deps}/lib''
         ''NIX_LD_LIBRARY_PATH=''${NIX_LD_LIBRARY_PATH:+''${NIX_LD_LIBRARY_PATH}:}${neovim-build-deps}/lib''
@@ -147,7 +147,6 @@ in
           "nvim/init.lua".source = ../../init.lua;
           "nvim/lua".source = ../../lua;
           "nvim/snips".source = ../../snips;
-          "nvim/tutor".source = ../../tutor;
         }
         // optionalAttrs cfg.bindLazyLock {
           "nvim/lazy-lock.json".source = ../../lazy-lock.json;
@@ -187,7 +186,6 @@ in
           extraPackages =
             [
               # Dependent packages used by default plugins
-              pkgs.doq
               pkgs.tree-sitter
             ]
             ++ optionals cfg.withBuildTools [
@@ -214,8 +212,6 @@ in
 
           extraPython3Packages =
             ps: with ps; [
-              docformatter
-              isort
               pynvim
             ];
         }

--- a/nixos/testEnv.nix
+++ b/nixos/testEnv.nix
@@ -1,6 +1,7 @@
-{ inputs
-, pkgs
-, ...
+{
+  inputs,
+  pkgs,
+  ...
 }:
 let
   testSettings =


### PR DESCRIPTION
## 背景

每日 cron (`update-flake-lock`) 在 [run 29378384313](https://github.com/charliie-dev/nvimdots.lua/actions/runs/29378384313) 失敗於 **Validate updated flake**：

```
error: untokenize-0.1.1 not supported for interpreter python3.14
… while calculating requiredPythonModules for python3.14-docformatter-1.7.8
```

cron 把 `flake.lock` 更新到 python3 預設為 3.14 的 nixpkgs，而 `docformatter` 的依賴 `untokenize` 尚未支援 3.14，導致 `nix flake check` 中止、lockfile 更新被卡住。

## 變更（參考上游 [ayamir/nvimdots#1588](https://github.com/ayamir/nvimdots/pull/1588)）

| Commit | 說明 |
|---|---|
| `fix(nixos)` | 移除 `docformatter`、`isort`、`doq` — 皆未使用（python 格式化/import 排序由 ruff 處理），且 `docformatter` 正是 CI 阻塞來源 |
| `fix(nixos)` | 移除指向不存在目錄的 `xdg.configFile."nvim/tutor"` 引用（本 fork 無 `tutor/`，realize module 時會爆 `Path 'tutor' does not exist`） |
| `fix(nixos)` | 移除 `CPLUS_INCLUDE_PATH` 多餘的冒號（空路徑元素 = CWD，與其餘 env var 不一致） |
| `style(nixos)` | 用 nixfmt (RFC) 重排 nix 檔，對齊上游風格 |
| `chore(nixos)` | devShell 的 nix formatter 從 `nixpkgs-fmt` 換成 `nixfmt-rfc-style`，讓宣告工具與實際格式一致 |
| `chore(lockfile)` | bump `flake.lock` 到 2026-07-15 nixpkgs，佐證修復後可正常評估 |

> **註**：原本有一個 `refactor: lua51Packages.luarocks → luaPackages.luarocks` commit，但在 review 中經 Codex 指出並驗證後撤除 —— `pkgs.luaPackages` 在 locked nixpkgs 指向 Lua **5.2**，而 Neovim 用 LuaJIT (5.1 ABI)、lazy.nvim 以 `--lua-version 5.1` build rockspec，故刻意保留 `pkgs.lua51Packages.luarocks`（5.1）。

## 驗證

- `nix flake check` ✅（`testEnv` build skipped）
- `nix eval .#packages.x86_64-linux.testEnv.drvPath` ✅（不再有 docformatter / tutor 錯誤）
- `nixfmt --check` 全部 nix 檔 clean
