### PR TITLE
fix: drop node-shim-era stdin overrides (markdownlint-cli2, prettier)

### DIFF
--- a/lua/modules/configs/completion/conform.lua
+++ b/lua/modules/configs/completion/conform.lua
@@ -163,16 +163,6 @@ return function()
 				args = { "fix", "--stdin" },
 				stdin = true,
 			},
-			-- prettier: the --write-on-temp-copy shape dates from the bun
-			-- node-shim era (stdin was broken); mise ships real node now, so
-			-- stdin likely works again — kept pending re-evaluation. `stdin =
-			-- false` points $FILENAME at a `.conform.$RANDOM.*` copy; the real
-			-- file is never touched.
-			prettier = {
-				command = "prettier",
-				args = { "--write", "$FILENAME" },
-				stdin = false,
-			},
 		},
 		format_on_save = format_on_save_enabled and function(bufnr)
 			if not autoformat_allowed(bufnr) then

--- a/lua/modules/configs/completion/conform.lua
+++ b/lua/modules/configs/completion/conform.lua
@@ -207,12 +207,23 @@ return function()
 			return { broken = tostring(config) }
 		end
 		if config then
-			-- A function-form command resolves per buffer at format time (e.g. the
-			-- builtin from_node_modules): treat it as self-resolving rather than
-			-- evaluating it for a representative binary — a node_modules command
-			-- shouldn't map to a Mason install anyway.
+			-- A function-form command (the builtin from_node_modules) resolves per
+			-- buffer at format time, so evaluate it against the probe-time buffer
+			-- the same way conform will: a project-local node_modules bin passes
+			-- the $PATH check as-is, and the bare-name FALLBACK ("prettier") keeps
+			-- the dep inside the install/warn contract — trusting the function
+			-- blindly would let a fresh machine with no copy anywhere silently
+			-- skip both the Mason install and the aggregated warning. A failed or
+			-- non-string evaluation degrades to self-resolving (no install/warn),
+			-- never to a typo report.
 			if type(config.command) == "function" then
-				return { binary = nil }
+				local fname = vim.api.nvim_buf_get_name(0)
+				local cmd_ok, cmd = pcall(config.command, config, {
+					buf = vim.api.nvim_get_current_buf(),
+					filename = fname,
+					dirname = fname ~= "" and vim.fs.dirname(fname) or vim.fn.getcwd(),
+				})
+				return { binary = (cmd_ok and type(cmd) == "string" and cmd ~= "") and cmd or nil }
 			end
 			return { binary = config.command }
 		end

--- a/lua/modules/configs/completion/nvim-lint.lua
+++ b/lua/modules/configs/completion/nvim-lint.lua
@@ -15,25 +15,17 @@ return function()
 				"-",
 			}
 		end,
-		-- markdownlint-cli2: file-based mode + stderr parser date from the bun
-		-- node-shim era (stdin's for-await yielded empty); mise ships real node
-		-- now, so stdin likely works again — kept pending re-evaluation.
-		-- NOTE (known limitation): the pattern requires "path:line:col", but
-		-- upstream omits the column when unknown (e.g. MD012), so those
-		-- findings are silently dropped.
+		-- markdownlint-cli2: only add the global config — it discovers configs
+		-- upward from the linted file, so projects without their own would
+		-- otherwise fall back to factory defaults. stdin mode and the parser
+		-- stay upstream's; its errorformat fallback ("stdin:%l %m") keeps
+		-- findings whose column is unknown (e.g. MD012).
 		["markdownlint-cli2"] = function(linter)
-			linter.stdin = false
 			linter.args = {
 				"--config",
 				vim.fn.stdpath("config") .. "/.markdownlint.yml",
+				"-",
 			}
-			linter.stream = "stderr"
-			linter.parser = require("lint.parser").from_pattern(
-				"[^:]+:(%d+):(%d+) (%a+) (.+)",
-				{ "lnum", "col", "severity", "message" },
-				{ ["error"] = vim.diagnostic.severity.ERROR, ["warning"] = vim.diagnostic.severity.WARN },
-				{ source = "markdownlint" }
-			)
 		end,
 	}
 	---@param name string


### PR DESCRIPTION
Stacked on #21 (`feat/discovery-first-tooling`) — re-target/rebase after it merges.

## What

Both remaining bun node-shim-era stdin workarounds are removed now that mise ships real node:

- **`fix(lint)`** — shrink the markdownlint-cli2 override to args-only (`--config` for the global `.markdownlint.yml` + `-`). stdin mode and the parser are inherited from upstream nvim-lint, whose errorformat fallback (`stdin:%l %m`) keeps findings that carry no column — the old `from_pattern` required `path:line:col`, so col-less findings (e.g. MD012/no-multiple-blanks) were silently dropped. stdin also means the buffer's live content is linted instead of the on-disk file.
- **`refactor(conform)`** — drop the prettier `--write`-on-temp-copy override; conform's built-in definition (stdin + `--stdin-filepath`) takes over, so no `.conform.$RANDOM.*` copy is written per format.

Audited the rest of both configs for the same class of issue: `selene` (args-only, config path) and `shuck` (file-based is the tool's own limitation; JSON parser has col fallbacks) are legitimate; `fixjson` is the only other node tool on a stdin path and works with real node (tested) — no override ever existed for it.

## Verification

- Headless lint of a markdown buffer: MD012 (col-less) ×2 + MD009 (with col) all reported; a 120-char line does **not** trigger MD013, proving `--config` applies through the stdin path.
- Headless `conform.format()` on a JS buffer: formatted via the built-in stdin definition (`stdin=true`, available).
- Harnesses: conform-probe-smoke, lint-reload-smoke, lint-sweep-smoke, lint-broken-reason-smoke — 17/17 scenarios PASS.
- `stylua --check` + `selene` clean.
